### PR TITLE
refactor: pass server port, cert, and cert key as env variables

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -70,6 +70,11 @@ jobs:
           echo "DEV_HUB_DEBUG=${{ secrets.DEV_HUB_DEBUG }}" >> .env
           echo "DEV_HUB_ALLOWED_HOSTS=${{ vars.DEV_HUB_ALLOWED_HOSTS }}" >> .env
           echo "DOMAIN=${{ vars.DOMAIN }}" >> .env
+          echo "DEV_HUB_HOST=${{ vars.DOMAIN }}" >> .env
+          echo "DEV_HUB_PORT=443" >> .env
+          echo "DEV_HUB_SSL_LIVE_DIR=/etc/letsencrypt/live/${{ vars.DOMAIN }}" >> .env
+          echo "DEV_HUB_SSL_ARCHIVE_DIR=/etc/letsencrypt/archive/${{ vars.DOMAIN }}" >> .env
+          echo "DEV_HUB_SSL_KEYS_DIR=/etc/letsencrypt/keys" >> .env
 
       - name: Copy .env file to EC2
         run: scp -o StrictHostKeyChecking=no -i private-key.pem .env ubuntu@${{ vars.DOMAIN }}:/home/ubuntu/dev_hub/.env

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,9 +14,16 @@ jobs:
       contents: read
     env:
       DEV_HUB_DJANGO_SECRET: ${{ secrets.DEV_HUB_DJANGO_SECRET }}
-      DEV_HUB_DEBUG: ${{ secrets.DEV_HUB_DEBUG }}
+      DEV_HUB_DEBUG: true
       DEV_HUB_ALLOWED_HOSTS: localhost,127.0.0.1
-      ACCEPTANCE_TEST_SERVER_URL: http://localhost:8000
+      ACCEPTANCE_TEST_SERVER_URL: https://localhost
+      DOMAIN: localhost
+      DEV_HUB_HOST: localhost
+      DEV_HUB_PORT: 443
+      DEV_HUB_SSL_LIVE_DIR: ./.certs/live/localhost
+      DEV_HUB_SSL_ARCHIVE_DIR: ./.certs/archive/localhost
+      DEV_HUB_SSL_KEYS_DIR: ./.certs/keys
+      PLAYWRIGHT_IGNORE_HTTPS_ERRORS: true
 
     steps:
       - name: Checkout code
@@ -35,15 +42,48 @@ jobs:
       - name: Ensure browsers are installed
         run: python -m playwright install --with-deps
 
+      - name: Generate Self Signed Certificate
+        run: |
+          mkdir -p ./.certs/live/localhost
+          mkdir -p ./.certs/archive/localhost
+          mkdir -p ./.certs/keys
+          openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+            -keyout ./.certs/live/localhost/privkey.pem \
+            -out ./.certs/live/localhost/fullchain.pem \
+            -subj "/C=US/ST=State/L=City/O=Organization/OU=Unit/CN=localhost"
+
       - name: Create .env file locally
         run: |
-          echo "DEV_HUB_DJANGO_SECRET=${{ secrets.DEV_HUB_DJANGO_SECRET }}" > .env
-          echo "DEV_HUB_DEBUG=${{ secrets.DEV_HUB_DEBUG }}" >> .env
-          echo "DEV_HUB_ALLOWED_HOSTS=${{ vars.DEV_HUB_ALLOWED_HOSTS }}" >> .env
+          echo "DEV_HUB_DJANGO_SECRET=$DEV_HUB_DJANGO_SECRET" > .env
+          echo "DEV_HUB_DEBUG=$DEV_HUB_DEBUG" >> .env
+          echo "DEV_HUB_ALLOWED_HOSTS=$DEV_HUB_ALLOWED_HOSTS" >> .env
+          echo "DOMAIN=$DOMAIN" >> .env
+          echo "DEV_HUB_HOST=$DEV_HUB_HOST" >> .env
+          echo "DEV_HUB_PORT=$DEV_HUB_PORT" >> .env
+          echo "DEV_HUB_SSL_LIVE_DIR=$DEV_HUB_SSL_LIVE_DIR" >> .env
+          echo "DEV_HUB_SSL_ARCHIVE_DIR=$DEV_HUB_SSL_ARCHIVE_DIR" >> .env
+          echo "DEV_HUB_SSL_KEYS_DIR=$DEV_HUB_SSL_KEYS_DIR" >> .env
+          echo "ACCEPTANCE_TEST_SERVER_URL=$ACCEPTANCE_TEST_SERVER_URL" >> .env
+          echo "PLAYWRIGHT_IGNORE_HTTPS_ERRORS=$PLAYWRIGHT_IGNORE_HTTPS_ERRORS" >> .env
 
-      - name: Run Dev Server
+      - name: Run NGINX Server
         run: |
-          python manage.py runserver &
+          docker compose up -d --build
+      
+      - name: Wait for the web server to be ready (with timeout)
+        run: |
+          timeout=60  # Timeout after 60 seconds
+          elapsed=0
+          while ! curl --silent --head --fail -k $ACCEPTANCE_TEST_SERVER_URL; do
+            if [ $elapsed -ge $timeout ]; then
+              echo "Timeout reached, web server is not up after $timeout seconds."
+              exit 1  # Fail the step
+            fi
+            echo "Waiting for web server to be ready... $elapsed seconds elapsed."
+            sleep 5
+            ((elapsed+=5))
+          done
+          echo "Web server is up and running!"
       
       - name: Run Django Tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ __pycache__
 
 # Django collected static files
 staticfiles
+
+# dev folders
+.certs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   web:
     build: .
     entrypoint: sh ./launch.sh
-    command: gunicorn --bind 0.0.0.0:8000 dev_hub.wsgi:application
+    command: gunicorn --bind 0.0.0.0:8001 dev_hub.wsgi:application
     volumes:
       - .:/app
       - ./staticfiles:/app/staticfiles  # Mount static files
@@ -11,7 +11,7 @@ services:
       DEV_HUB_DEBUG: ${DEV_HUB_DEBUG}
       DEV_HUB_ALLOWED_HOSTS: ${DEV_HUB_ALLOWED_HOSTS}
     ports:
-      - "8000:8000"
+      - "8001:8001"
     restart: always
 
   nginx:
@@ -19,15 +19,15 @@ services:
     environment:
       DOMAIN: ${DOMAIN}
     ports:
-      - "80:80"
-      - "443:443"
+      - 80:80
+      - ${DEV_HUB_PORT}:443
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/templates:/etc/nginx/templates
       - ./staticfiles:/app/staticfiles  # Serve collected static files
-      - /etc/letsencrypt/live/${DOMAIN}:/etc/letsencrypt/live/${DOMAIN}:ro
-      - /etc/letsencrypt/archive/${DOMAIN}:/etc/letsencrypt/archive/${DOMAIN}:ro
-      - /etc/letsencrypt/keys:/etc/letsencrypt/keys:ro
+      - ${DEV_HUB_SSL_LIVE_DIR}:/etc/letsencrypt/live/${DOMAIN}:ro
+      - ${DEV_HUB_SSL_ARCHIVE_DIR}:/etc/letsencrypt/archive/${DOMAIN}:ro
+      - ${DEV_HUB_SSL_KEYS_DIR}:/etc/letsencrypt/keys:ro
     depends_on:
       - web
     restart: always

--- a/launch.sh
+++ b/launch.sh
@@ -10,4 +10,4 @@ echo "Collecting static files..."
 python manage.py collectstatic --noinput
 
 echo "Starting Gunicorn..."
-exec gunicorn --bind 0.0.0.0:8000 dev_hub.wsgi:application
+exec gunicorn --bind 0.0.0.0:8001 dev_hub.wsgi:application

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -29,7 +29,7 @@ server {
     }
 
     location / {
-        proxy_pass http://web:8000;  # Forward requests to the Django app
+        proxy_pass http://web:8001;  # Forward requests to the Django app
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
update test and deploy workflows to set up .env file with these new environment variables

update default port for dev_hub gunicorn server to 8001

update launch script to run gunicorn at port 8001

update .gitignore to ignore local .certs directory

bind local SLL key and cert directories to expected directories in nginx container using docker compose